### PR TITLE
Add Repology badge to README for packaging status

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ cargo install intentrace
 ```
 
 
+### Package Manager Availability 
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/intentrace.svg)](https://repology.org/project/intentrace/versions)
+
+
+
+
+
 ## Project status
 
 intentrace is currently in beta, currently multi-threaded programs are a hit and miss.


### PR DESCRIPTION
This PR adds a Repology badge to the README file to display the packaging status of intentrace across various package managers. The badge dynamically updates as more package managers adopt the project, providing users with up-to-date information.