### PR TITLE
Fix copy-paste error in fallocate FALLOC_FL_INSERT_RANGE

### DIFF
--- a/src/one_line_formatter.rs
+++ b/src/one_line_formatter.rs
@@ -6554,7 +6554,8 @@ impl SyscallObject {
                                 );
                                 self.general_text(")");
                             }
-                        } else if mode.contains(nix::fcntl::FallocateFlags::FALLOC_FL_ZERO_RANGE) {
+                        } else if mode.contains(nix::fcntl::FallocateFlags::FALLOC_FL_INSERT_RANGE)
+                        {
                             self.write_text("insert ".magenta());
                             self.write_text(bytes.custom_color(*OUR_YELLOW));
                             self.write_text(" of holes".magenta());


### PR DESCRIPTION
Completely untested (it does at least build)

I just cloned intentrace to debug a different issue, and my editor is configured to run clippy automatically. Clippy complained that this branch was unreachable, and I noticed it was a copy-paste error.

I figured I would upload this now to share in case I got distracted and never revisited this, but it should honestly probably get some testing (and ideally some tests) before getting merged